### PR TITLE
Parent Identifier

### DIFF
--- a/src/main/java/com/coveros/selenified/element/Element.java
+++ b/src/main/java/com/coveros/selenified/element/Element.java
@@ -48,7 +48,7 @@ import java.util.List;
  *
  * @author Max Saperstone
  * @version 3.1.0
- * @lastupdate 2/21/2019
+ * @lastupdate 3/5/2019
  */
 public class Element {
 
@@ -207,7 +207,7 @@ public class Element {
         this.file = file;
 
         App app = null;
-        if ( file != null ) {
+        if (file != null) {
             app = file.getApp();
         }
 
@@ -282,7 +282,23 @@ public class Element {
      * @return String: text identifying how the element was located
      */
     public String prettyOutputStart() {
-        return "Element with <i>" + type.toString() + "</i> of <i>" + locator + "</i>";
+        return prettyOutputStart("Element with ");
+    }
+
+    /**
+     * Builds the nicely HTML formatted output of the element by retrieving parent
+     * element information
+     *
+     * @param initialString - the starting string, typically describing the element,
+     *                      or initial parent element
+     * @return String: text identifing how the element was located
+     */
+    private String prettyOutputStart(String initialString) {
+        initialString += "<i>" + type.toString() + "</i> of <i>" + locator + "</i>";
+        if (parent != null) {
+            initialString = parent.prettyOutputStart(initialString + " and parent of ");
+        }
+        return initialString;
     }
 
     /**

--- a/src/test/java/unit/ElementTest.java
+++ b/src/test/java/unit/ElementTest.java
@@ -118,6 +118,18 @@ public class ElementTest {
     }
 
     @Test
+    public void checkPrettyOutputParentTest() {
+        Element element = new Element(null, null, Locator.ID, "myId", new Element(null, null, Locator.NAME, "parentId"));
+        assertEquals(element.prettyOutput(), " element with <i>ID</i> of <i>myId</i> and parent of <i>NAME</i> of <i>parentId</i> ");
+    }
+
+    @Test
+    public void checkPrettyOutputGrandParentTest() {
+        Element element = new Element(null, null, Locator.ID, "myId", new Element(null, null, Locator.NAME, "parentId", new Element(null, null, Locator.TAGNAME, "grandParentId")));
+        assertEquals(element.prettyOutput(), " element with <i>ID</i> of <i>myId</i> and parent of <i>NAME</i> of <i>parentId</i> and parent of <i>TAGNAME</i> of <i>grandParentId</i> ");
+    }
+
+    @Test
     public void checkPrettyOutputStartTest() {
         Element element = new Element(null, null, Locator.ID, "myId");
         assertEquals(element.prettyOutputStart(), "Element with <i>ID</i> of <i>myId</i>");


### PR DESCRIPTION
Adding additional information for locating element based on parent information if it exists for logging. Currently, when using child elements, logging is confusing, and not detailed enough.
Addresses #145 

I'm not certain that my logic is as simple as it can be. It works (verified via UTs), but I'm not thrilled with it. A comment or point in the right direction would be appreciated if you think it can be made better